### PR TITLE
st1 [2253][FIX] website_sale_charge_payment_fee

### DIFF
--- a/website_sale_charge_payment_fee/templates/website_sale.xml
+++ b/website_sale_charge_payment_fee/templates/website_sale.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 <odoo>
-
-
     <template id="payment_fee" inherit_id="website_sale.payment">
         <xpath expr="//span[@t-if='acquirer.fees_active']" position="after">
             <t t-if="acquirer.charge_fee">
@@ -39,21 +37,4 @@
             </t>
         </xpath>
     </template>
-
-    <record id="custom_customer_view_sale_order_inherit_form2" model="ir.ui.view">
-        <field name="name">sale.order.form2</field>
-        <field name="model">sale.order</field>
-        <field name="inherit_id" ref="sale.view_order_form"/>
-        <field name="arch" type="xml">
-            <xpath expr="//tree/field[@name='discount_price']" position="after">
-                <field name="payment_fee_line"/>
-            </xpath>
-            <xpath expr="//form/group/group/field[@name='note']" position="after">
-            	<field name="payment_fee_line"/>
-            </xpath>
-        </field>
-    </record>
-
-
-
 </odoo>


### PR DESCRIPTION
[2253](https://www.quartile.co/web#id=2253&action=771&active_id=2156&model=project.task&view_type=form&menu_id=505)

Remove pro_mi7_website_sale_product_list.checkout since xpaths point to some random custom fields which are not in the inheritance chain.