### PR TITLE
[6282][IMP] mail_post_defer: consider force_send context

### DIFF
--- a/mail_post_defer/models/mail_thread.py
+++ b/mail_post_defer/models/mail_thread.py
@@ -12,8 +12,10 @@ class MailThread(models.AbstractModel):
     def message_post(self, **kwargs):
         """Post messages using queue by default."""
         _self = self
-        force_send = self.env.context.get("mail_notify_force_send") or kwargs.get(
-            "force_send", False
+        force_send = (
+            self.env.context.get("mail_notify_force_send")
+            or self.env.context.get("force_send")
+            or kwargs.get("force_send", False)
         )
         kwargs.setdefault("force_send", force_send)
         if not force_send:

--- a/mail_post_defer/tests/test_mail.py
+++ b/mail_post_defer/tests/test_mail.py
@@ -69,6 +69,30 @@ class MessagePostCase(MailCommon):
                 fields_values={"scheduled_date": False},
             )
 
+    def test_forced_context_with_template(self):
+        """A forced send via context is sent directly when using a template."""
+        with self.mock_mail_gateway():
+            mail_template = self.env["mail.template"].create(
+                {
+                    "model_id": self.env.ref("base.model_res_partner").id,
+                    "body_html": "<p>test body</p>",
+                    "partner_to": f"{self.partner_employee.id}",
+                }
+            )
+            self.partner_portal.with_context(
+                force_send=True
+            ).message_post_with_template(
+                mail_template.id,
+                composition_mode="comment",
+            )
+            self.assertMailMail(
+                self.partner_employee,
+                "sent",
+                author=self.env.user.partner_id,
+                content="test body",
+                fields_values={"scheduled_date": False},
+            )
+
     def test_no_msg_edit(self):
         """Cannot update messages.
 


### PR DESCRIPTION
[6282](https://www.quartile.co/web#id=6282&cids=3&model=project.task&view_type=form)

Standard Odoo modules (e.g. sale.order) use with_context(force_send=True) to request immediate email delivery. However, mail_post_defer was not checking force_send in context, causing these emails to be deferred unexpectedly. This change adds the context check so that force_send=True in context is properly considered.